### PR TITLE
fix(Dockerfile): fix "Github deploy key chmod" logic

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -63,8 +63,8 @@ RUN ansible-galaxy install elastic.elasticsearch,5.5.1
 # Single step so that deploy key is not committed to image
 RUN if [ ! -z "$GITHUB_DEPLOY_KEY_BASE64" ] \
     ; then echo "$GITHUB_DEPLOY_KEY_BASE64" | base64 -d > "$GITHUB_DEPLOY_KEY_FILE" \
+      && chmod 0600 "$GITHUB_DEPLOY_KEY_FILE" \
   ; fi \
-  && chmod 0600 "$GITHUB_DEPLOY_KEY_FILE" \
   && ansible-playbook -i "localhost," -c local site.yml -vv \
   && if [ -f "$GITHUB_DEPLOY_KEY_FILE" ] ; then rm -fv "$GITHUB_DEPLOY_KEY_FILE" ; fi
 


### PR DESCRIPTION
When no Github deployment key was provided, the Docker build would try to perform a chmod on a file that doesn't exist.

This moves the chmod command into the if statement, so it should only run if there is a Github deploy key available